### PR TITLE
fix: ETH balance subtraction

### DIFF
--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -85,7 +85,8 @@ const CoinSelection = () => {
         ({ address }) => address === selectedItem!.address
       );
       const balance = balances[selectedIndex];
-      if (amount.lte(balance)) {
+      const isEth = tokenList[selectedIndex].symbol === "ETH";
+      if (amount.lte(isEth ? balance.sub(ethers.utils.parseEther("0.004")) : balance)) {
         // clear the previous error if it is not a parsing error
         setError((oldError) => {
           if (oldError instanceof ParsingError) {
@@ -104,7 +105,8 @@ const CoinSelection = () => {
       const selectedIndex = tokenList.findIndex(
         ({ address }) => address === selectedItem.address
       );
-      const balance = balances[selectedIndex];
+      const isEth = tokenList[selectedIndex].symbol === "ETH";
+      const balance = isEth ? balances[selectedIndex].sub(ethers.utils.parseEther("0.004")) : balances[selectedIndex];
       setAmount({ amount: balance });
       setInputAmount(formatUnits(balance, selectedItem.decimals));
     }

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -23,7 +23,6 @@ import {
 import { useAllowance, useBridgeFees } from "./chainApi";
 import { add } from "./transactions";
 import { deposit as depositAction, toggle } from "./deposits";
-import { parseEther } from "@ethersproject/units";
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch = () => useDispatch<AppDispatch>();
@@ -165,7 +164,7 @@ export function useSend() {
       const depositBox = getDepositBox(fromChain, signer);
       const isETH = token === ethers.constants.AddressZero;
       const value = isETH
-        ? amount.sub(parseEther("0.002"))
+        ? amount
         : ethers.constants.Zero;
       const l2Token = isETH ? TOKENS_LIST[fromChain][0].address : token;
       const { instantRelayFee, slowRelayFee } = fees;
@@ -174,7 +173,7 @@ export function useSend() {
       const tx = await depositBox.deposit(
         toAddress,
         l2Token,
-        isETH ? amount.sub(parseEther("0.002")) : amount,
+        amount,
         slowRelayFee.pct,
         instantRelayFee.pct,
         timestamp,


### PR DESCRIPTION
We should subtract a small amount from the user's ETH balance when setting the MAX value and when issuing insufficient balance warnings rather than subtracting the small amount from the user input when sending the txn.

We should always send exactly as much as the user enters into the text box.

Note: this also bumps the amount subtracted from 0.002 ETH to 0.004 ETH since currently arbitrum fees are high enough s.t. 0.002 isn't sufficient. In the future, we can make the subtracted amount dynamic.