### PR TITLE
fix: fix onboard crashing due to re-init on tab select

### DIFF
--- a/src/components/ChainSelection/ChainSelection.tsx
+++ b/src/components/ChainSelection/ChainSelection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useOnboard } from "hooks";
+import { onboard } from "hooks";
 import { useConnection, useSend } from "state/hooks";
 import { CHAINS, switchChain } from "utils";
 import { Section, SectionTitle } from "../Section";
@@ -11,7 +11,7 @@ import {
 } from "./ChainSelection.styles";
 
 const ChainSelection: React.FC = () => {
-  const { init } = useOnboard();
+  const { init } = onboard;
   const { isConnected, provider } = useConnection();
   const { hasToSwitchChain, fromChain } = useSend();
 

--- a/src/components/ChainSelection/ChainSelection.tsx
+++ b/src/components/ChainSelection/ChainSelection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { onboard } from "hooks";
+import { onboard } from "utils";
 import { useConnection, useSend } from "state/hooks";
 import { CHAINS, switchChain } from "utils";
 import { Section, SectionTitle } from "../Section";

--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -110,6 +110,7 @@ const CoinSelection = () => {
         ({ address }) => address === selectedItem.address
       );
       const isEth = tokenList[selectedIndex].symbol === "ETH";
+      // TODO: need to select max of 0 and balances.sub. 
       const balance = isEth
         ? balances[selectedIndex].sub(ethers.utils.parseEther("0.004"))
         : balances[selectedIndex];

--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -86,7 +86,11 @@ const CoinSelection = () => {
       );
       const balance = balances[selectedIndex];
       const isEth = tokenList[selectedIndex].symbol === "ETH";
-      if (amount.lte(isEth ? balance.sub(ethers.utils.parseEther("0.004")) : balance)) {
+      if (
+        amount.lte(
+          isEth ? balance.sub(ethers.utils.parseEther("0.004")) : balance
+        )
+      ) {
         // clear the previous error if it is not a parsing error
         setError((oldError) => {
           if (oldError instanceof ParsingError) {
@@ -106,7 +110,9 @@ const CoinSelection = () => {
         ({ address }) => address === selectedItem.address
       );
       const isEth = tokenList[selectedIndex].symbol === "ETH";
-      const balance = isEth ? balances[selectedIndex].sub(ethers.utils.parseEther("0.004")) : balances[selectedIndex];
+      const balance = isEth
+        ? balances[selectedIndex].sub(ethers.utils.parseEther("0.004"))
+        : balances[selectedIndex];
       setAmount({ amount: balance });
       setInputAmount(formatUnits(balance, selectedItem.decimals));
     }

--- a/src/components/PoolForm/AddLiquidityForm.tsx
+++ b/src/components/PoolForm/AddLiquidityForm.tsx
@@ -1,5 +1,5 @@
 import { FC, ChangeEvent } from "react";
-import { onboard } from "hooks";
+import { onboard } from "utils";
 import { useConnection } from "state/hooks";
 import {
   RoundBox,

--- a/src/components/PoolForm/AddLiquidityForm.tsx
+++ b/src/components/PoolForm/AddLiquidityForm.tsx
@@ -1,5 +1,5 @@
 import { FC, ChangeEvent } from "react";
-import { useOnboard } from "hooks";
+import { onboard } from "hooks";
 import { useConnection } from "state/hooks";
 import {
   RoundBox,
@@ -17,7 +17,7 @@ interface Props {
 }
 
 const AddLiquidityForm: FC<Props> = ({ error, amount, onChange }) => {
-  const { init } = useOnboard();
+  const { init } = onboard;
   const { isConnected, provider } = useConnection();
 
   const handleButtonClick = () => {

--- a/src/components/PoolForm/RemoveLiquidityForm.tsx
+++ b/src/components/PoolForm/RemoveLiquidityForm.tsx
@@ -1,6 +1,6 @@
 import { FC, Dispatch, SetStateAction } from "react";
 import PoolFormSlider from "./PoolFormSlider";
-import { onboard } from "hooks";
+import { onboard } from "utils";
 import { useConnection } from "state/hooks";
 import {
   RemoveAmount,

--- a/src/components/PoolForm/RemoveLiquidityForm.tsx
+++ b/src/components/PoolForm/RemoveLiquidityForm.tsx
@@ -1,6 +1,6 @@
 import { FC, Dispatch, SetStateAction } from "react";
 import PoolFormSlider from "./PoolFormSlider";
-import { useOnboard } from "hooks";
+import { onboard } from "hooks";
 import { useConnection } from "state/hooks";
 import {
   RemoveAmount,
@@ -15,7 +15,7 @@ interface Props {
   setRemoveAmount: Dispatch<SetStateAction<number>>;
 }
 const RemoveLiqudityForm: FC<Props> = ({ removeAmount, setRemoveAmount }) => {
-  const { init } = useOnboard();
+  const { init } = onboard;
   const { isConnected, provider } = useConnection();
 
   const handleButtonClick = () => {

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -68,11 +68,11 @@ const SendAction: React.FC = () => {
       return;
     }
     if (hasToApprove) {
-      handleApprove();
+      handleApprove().catch((err) => console.error(err));
       return;
     }
     if (canSend) {
-      handleSend();
+      handleSend().catch((err) => console.error(err));
     }
   };
 

--- a/src/components/Wallet/Wallet.tsx
+++ b/src/components/Wallet/Wallet.tsx
@@ -1,4 +1,4 @@
-import { useOnboard } from "hooks";
+import { onboard } from "hooks";
 import React from "react";
 import { useConnection, useETHBalance } from "state/hooks";
 import {
@@ -11,7 +11,7 @@ import { Wrapper, Account, Info, ConnectButton } from "./Wallet.styles";
 
 const Wallet: React.FC = () => {
   const { account, isConnected, chainId } = useConnection();
-  const { init } = useOnboard();
+  const { init } = onboard;
 
   const { data: balance } = useETHBalance(
     { account: account ?? "", chainId: chainId ?? DEFAULT_FROM_CHAIN_ID },

--- a/src/components/Wallet/Wallet.tsx
+++ b/src/components/Wallet/Wallet.tsx
@@ -1,4 +1,4 @@
-import { onboard } from "hooks";
+import { onboard } from "utils";
 import React from "react";
 import { useConnection, useETHBalance } from "state/hooks";
 import {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,1 @@
-export * from "./useOnboard";
 export * from "./useERC20";

--- a/src/hooks/useOnboard.ts
+++ b/src/hooks/useOnboard.ts
@@ -1,54 +1,65 @@
-import React from "react";
+// import React from "react";
 import Onboard from "bnc-onboard";
-import { Wallet } from "bnc-onboard/dist/src/interfaces";
+import { Wallet, Initialization } from "bnc-onboard/dist/src/interfaces";
 import { ethers } from "ethers";
 import { onboardBaseConfig } from "utils";
-import { useConnection } from "state/hooks";
+import { update,disconnect,error } from "state/connection";
+import {store} from 'state'
 
-export function useOnboard() {
-  const { disconnect, setUpdate, setError } = useConnection();
+export type Emit = (event:string, data?:any) => void
+export function OnboardReact(config:Initialization, emit:Emit){
+  const onboard = Onboard({
+    ...config,
+    subscriptions: {
+      address: (address: string) => {
+        emit('update',{ account: address });
+      },
+      network: (chainIdInHex) => {
+        if (chainIdInHex == null) {
+          return;
+        }
+        const chainId = ethers.BigNumber.from(chainIdInHex).toNumber();
 
-  const instance = React.useMemo(
-    () =>
-      Onboard({
-        ...onboardBaseConfig(),
-        subscriptions: {
-          address: (address: string) => {
-            setUpdate({ account: address });
-          },
-          network: (chainIdInHex) => {
-            if (chainIdInHex == null) {
-              return;
-            }
-            const chainId = ethers.BigNumber.from(chainIdInHex).toNumber();
-
-            setUpdate({ chainId });
-          },
-          wallet: (wallet: Wallet) => {
-            const provider = new ethers.providers.Web3Provider(wallet.provider);
-            const signer = provider.getSigner();
-            setUpdate({
-              account: wallet.provider.selectedAddress,
-              provider,
-              signer,
-            });
-          },
-        },
-      }),
-    [setUpdate]
-  );
-
-  const init = React.useCallback(async () => {
-    try {
-      await instance.walletSelect();
-      await instance.walletCheck();
-    } catch (error: unknown) {
-      setError({ error: new Error("Could not initialize Onboard.") });
+        emit('update',{ chainId });
+      },
+      wallet: (wallet: Wallet) => {
+        const provider = new ethers.providers.Web3Provider(wallet.provider);
+        const signer = provider.getSigner();
+        emit('update',{
+          account: wallet.provider.selectedAddress,
+          provider,
+          signer,
+        });
+      },
+    },
+  })
+  async function init(){
+    try{
+    await onboard.walletSelect();
+    await onboard.walletCheck();
+      emit('init')
+    }catch(err:any){
+      emit('error',new Error("Could not initialize Onboard: " + err.message as string)) 
     }
-  }, [instance, setError]);
-  const reset = React.useCallback(() => {
-    instance.walletReset();
-    disconnect();
-  }, [instance, disconnect]);
-  return { init, reset };
+  }
+  async function reset(){
+    try{
+      await onboard.walletReset();
+      emit('disconnect')
+    }catch(err){
+      emit('error',err)
+    }
+  }
+  return { init, reset, onboard };
 }
+export const onboard = OnboardReact(onboardBaseConfig(),(event,data)=>{
+  if(event === 'update'){
+    store.dispatch(update(data))
+  }
+  if(event === 'disconnect'){
+    store.dispatch(disconnect())
+  }
+  if(event === 'error'){
+    store.dispatch(error(data))
+  }
+})

--- a/src/state/connection.ts
+++ b/src/state/connection.ts
@@ -36,7 +36,6 @@ const connectionSlice = createSlice({
       if (chainId) {
         if (isSupportedChainId(chainId)) {
           state.chainId = chainId;
-          // Clear the error if the chainId is correctly set
           if (state.error instanceof UnsupportedChainIdError) {
             state.error = undefined;
           }

--- a/src/state/connection.ts
+++ b/src/state/connection.ts
@@ -30,8 +30,10 @@ const connectionSlice = createSlice({
   reducers: {
     update: (state, action: PayloadAction<Update>) => {
       const { account, chainId, provider, signer } = action.payload;
-      state.account = getAddress(account ?? state.account);
+      state.account = getAddress(account) ?? state.account;
       state.provider = provider ?? state.provider;
+      // theres a potential problem with this: if onboard says a signer is undefined, we default them back
+      // to the previous signer. This means we get out of sync with onboard and could have serious consequences.
       state.signer = signer ?? state.signer;
       if (chainId) {
         if (isSupportedChainId(chainId)) {

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -40,7 +40,6 @@ export function useConnection() {
   );
 
   const isConnected = !!chainId && !!signer && !!account;
-
   return {
     account,
     chainId,
@@ -181,7 +180,6 @@ export function useSend() {
       );
       return tx;
     } catch (e) {
-      console.error(e);
       throw new TransactionError(
         depositBox.address,
         "deposit",

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -55,25 +55,27 @@ export function useConnection() {
 
 // TODO: put this back into global state. Wasnt able to get it working.
 export function useBlocks(toChain: ChainId) {
-  const [state, setBlock] = useState< ethers.providers.Block & { blockNumber: number } | undefined >()
+  const [state, setBlock] = useState<
+    (ethers.providers.Block & { blockNumber: number }) | undefined
+  >();
   useEffect(() => {
     const provider = PROVIDERS[toChain]();
-    provider.getBlock('latest')
-      .then(block=>{
-        setBlock({...block,blockNumber:block.number})
+    provider
+      .getBlock("latest")
+      .then((block) => {
+        setBlock({ ...block, blockNumber: block.number });
       })
-      .catch(error=>console.error('Error getting block',error))
-      .finally(()=>{
-         provider.on("block", async (blockNumber: number) => {
-           const block = await provider.getBlock(blockNumber);
-           setBlock({ ...block, blockNumber });
-         });
-      })
+      .catch((error) => console.error("Error getting block", error))
+      .finally(() => {
+        provider.on("block", async (blockNumber: number) => {
+          const block = await provider.getBlock(blockNumber);
+          setBlock({ ...block, blockNumber });
+        });
+      });
 
     return () => {
       provider.removeAllListeners();
     };
-
   }, [toChain]);
 
   return {
@@ -162,9 +164,7 @@ export function useSend() {
     try {
       const depositBox = getDepositBox(fromChain, signer);
       const isETH = token === ethers.constants.AddressZero;
-      const value = isETH
-        ? amount
-        : ethers.constants.Zero;
+      const value = isETH ? amount : ethers.constants.Zero;
       const l2Token = isETH ? TOKENS_LIST[fromChain][0].address : token;
       const { instantRelayFee, slowRelayFee } = fees;
       const timestamp = block.timestamp;

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -28,4 +28,3 @@ setupListeners(store.dispatch);
 
 export type AppDispatch = typeof store.dispatch;
 export type RootState = ReturnType<typeof store.getState>;
-

--- a/src/utils/bridge.ts
+++ b/src/utils/bridge.ts
@@ -138,20 +138,16 @@ export async function getLpFee(
     bridgePoolAddress,
     provider
   );
-  
+
   const [currentUt, nextUt] = await Promise.all([
     bridgePool.callStatic.liquidityUtilizationCurrent(),
     bridgePool.callStatic.liquidityUtilizationPostRelay(amount),
   ]);
 
-  const result = {pct:BigNumber.from(0), total:BigNumber.from(0)}
-  if(!currentUt.eq(nextUt)){
-    result.pct = calculateRealizedLpFeePct(
-      RATE_MODEL,
-      currentUt,
-      nextUt
-    );
+  const result = { pct: BigNumber.from(0), total: BigNumber.from(0) };
+  if (!currentUt.eq(nextUt)) {
+    result.pct = calculateRealizedLpFeePct(RATE_MODEL, currentUt, nextUt);
     result.total = amount.mul(result.pct);
   }
-  return result
+  return result;
 }

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -26,11 +26,9 @@ export async function switchChain(
         ]);
       } catch (addError) {
         console.error(`Failed to add ${CHAINS[chainId].name}`);
-        throw switchError;
       }
     } else {
       console.error(`Failed to switch to ${CHAINS[chainId].name}`);
-      throw switchError;
     }
   }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from "./format";
 export * from "./bridge";
 export * from "./chains";
 export * from "./errors";
+export * from "./onboard";


### PR DESCRIPTION
This bug caused the app to crash when connecting wallet and switching tabs to the pool tab or vice versa.

This bug was caused by onboard being instantiated multiple times due to parent components unmounting and remounting. Moved onboard to be initialized outside of react and emit events to store directly.

Fixed another bug while this is open:  on chain change, the provider is wrong. Ethers assumes an immutable rpc provider. THe fix is to re-instance ethers when a chain change is detected.