### PR TITLE
fix: fix to address on deposit confirmation screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "prettier --write ./src/**.ts*"
   },
   "eslintConfig": {
     "extends": [
@@ -61,6 +62,7 @@
     ]
   },
   "devDependencies": {
-    "@types/react-slider": "^1.3.1"
+    "@types/react-slider": "^1.3.1",
+    "prettier": "^2.4.1"
   }
 }

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -15,7 +15,7 @@ import { PrimaryButton, AccentSection } from "components";
 import { Wrapper, Info } from "./SendAction.styles";
 
 const SendAction: React.FC = () => {
-  const { amount, fromChain, toChain, token, send, hasToApprove, canSend } =
+  const { amount, fromChain, toChain, token, send, hasToApprove, canSend, toAddress } =
     useSend();
   const { account } = useConnection();
 
@@ -60,7 +60,7 @@ const SendAction: React.FC = () => {
     if (tx) {
       addTransaction({ ...tx, meta: { label: TransactionTypes.DEPOSIT } });
       const receipt = await tx.wait();
-      addDeposit({ tx: receipt, toChain, fromChain, amount, token });
+      addDeposit({ tx: receipt, toChain, fromChain, amount, token, toAddress });
     }
   };
   const handleClick = () => {

--- a/src/state/deposits.ts
+++ b/src/state/deposits.ts
@@ -6,6 +6,7 @@ type Deposit = {
   txHash: string;
   amount: ethers.BigNumber;
   to: string;
+  toAddress?: string;
   from: string;
   token: string;
   fromChain: ChainId;
@@ -27,6 +28,7 @@ type DepositAction = PayloadAction<{
   amount: ethers.BigNumber;
   fromChain: ChainId;
   toChain: ChainId;
+  toAddress?: string;
 }>;
 
 const connectionSlice = createSlice({
@@ -48,6 +50,7 @@ const connectionSlice = createSlice({
       const from = depositTx.from;
       const to = depositTx.to;
       const token = action.payload.token;
+      const toAddress = action.payload.toAddress;
       state.tx = depositTx;
       state.deposit = {
         txHash: depositTx.transactionHash,
@@ -57,6 +60,7 @@ const connectionSlice = createSlice({
         from,
         fromChain,
         toChain,
+        toAddress,
       };
       state.showConfirmationScreen = true;
       return state;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -36,3 +36,4 @@ export function parseUnits(value: string, decimals: number): ethers.BigNumber {
 export function parseEther(value: string): ethers.BigNumber {
   return parseUnits(value, 18);
 }
+

--- a/src/views/Confirmation/Confirmation.tsx
+++ b/src/views/Confirmation/Confirmation.tsx
@@ -73,7 +73,7 @@ const Confirmation: React.FC = () => {
                   src={CHAINS[deposit.toChain].logoURI}
                   alt={`${CHAINS[deposit.toChain].name} logo`}
                 />
-                <div>{deposit.to}</div>
+                <div>{deposit.toAddress}</div>
               </div>
             </Info>
             <Info>

--- a/yarn.lock
+++ b/yarn.lock
@@ -13329,6 +13329,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+
 pretty-bytes@^5.3.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Bug existed because we were showing the "to" field on the send transaction, which was equal to the bridge deposit contract address. This was changed to the "toAddress" parameter in the transaction data, which is the actual users address receiving the funds. 