### PR TITLE
fix: update token balances after sucessful send

### DIFF
--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -35,6 +35,8 @@ const SendAction: React.FC = () => {
   const { approve } = useERC20(token);
   const { signer } = useConnection();
   const [updateEthBalance] = api.endpoints.ethBalance.useLazyQuery()
+  // trigger balance update
+  const [updateBalances] = api.endpoints.balances.useLazyQuery()
   const tokenInfo = TOKENS_LIST[fromChain].find((t) => t.address === token);
 
   const { data: fees } = useBridgeFees(
@@ -74,6 +76,7 @@ const SendAction: React.FC = () => {
       // update balances after tx
       if(account){
         updateEthBalance({chainId:fromChain,account});
+        updateBalances({chainId:fromChain,account});
       }
     }
   };


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

This uses `lazyQuery` from redux toolkit to fire off a fetch balances after a send succeeds