### PR TITLE
fix: use max approval to prevent approvals from being required again

### DIFF
--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import {ethers} from 'ethers'
 import {
   useBridgeFees,
   useConnection,
@@ -14,6 +15,8 @@ import { CHAINS, getDepositBox, TOKENS_LIST, formatUnits } from "utils";
 import { PrimaryButton, AccentSection } from "components";
 import { Wrapper, Info } from "./SendAction.styles";
 
+const CONFIRMATIONS = 1
+const MAX_APPROVAL_AMOUNT = ethers.constants.MaxUint256
 const SendAction: React.FC = () => {
   const { amount, fromChain, toChain, token, send, hasToApprove, canSend, toAddress } =
     useSend();
@@ -48,10 +51,10 @@ const SendAction: React.FC = () => {
     { skip: !account }
   );
   const handleApprove = async () => {
-    const tx = await approve({ amount, spender: depositBox.address, signer });
+    const tx = await approve({ amount:MAX_APPROVAL_AMOUNT, spender: depositBox.address, signer });
     if (tx) {
       addTransaction({ ...tx, meta: { label: TransactionTypes.APPROVE } });
-      await tx.wait();
+      await tx.wait(CONFIRMATIONS);
       refetch();
     }
   };
@@ -59,7 +62,7 @@ const SendAction: React.FC = () => {
     const tx = await send();
     if (tx) {
       addTransaction({ ...tx, meta: { label: TransactionTypes.DEPOSIT } });
-      const receipt = await tx.wait();
+      const receipt = await tx.wait(CONFIRMATIONS);
       addDeposit({ tx: receipt, toChain, fromChain, amount, token, toAddress });
     }
   };


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

https://app.shortcut.com/uma-project/story/2811/i-ve-already-approved-usdc-but-it-keeps-requesting-me-to-approve-again-this-has-happened-3-times

Unable to directly reproduce this, but after looking at code, the approvals were only doing the amount to send. This would probably cause a problem like this.  Made 2 changes here, added a constant for confirmations before refreshing state ( just in case its an issue with chain being out of sync) and also add a constant for max_approval amount, so user will not have to request again.