### PR TITLE
fix: check balance before enabling approve/send button

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "prettier --write ./src/**.ts*"
+    "lint": "prettier --write ./src"
   },
   "eslintConfig": {
     "extends": [

--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -110,7 +110,7 @@ const CoinSelection = () => {
         ({ address }) => address === selectedItem.address
       );
       const isEth = tokenList[selectedIndex].symbol === "ETH";
-      // TODO: need to select max of 0 and balances.sub. 
+      // TODO: need to select max of 0 and balances.sub.
       const balance = isEth
         ? balances[selectedIndex].sub(ethers.utils.parseEther("0.004"))
         : balances[selectedIndex];

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -8,7 +8,6 @@ import {
   useTransactions,
   useBlocks,
   useAllowance,
-  useBalance,
 } from "state/hooks";
 import { TransactionTypes } from "state/transactions";
 import { useERC20 } from "hooks";
@@ -27,6 +26,7 @@ const SendAction: React.FC = () => {
     token,
     send,
     hasToApprove,
+    canApprove,
     canSend,
     toAddress,
   } = useSend();
@@ -42,11 +42,6 @@ const SendAction: React.FC = () => {
   // trigger balance update
   const [updateBalances] = api.endpoints.balances.useLazyQuery();
   const tokenInfo = TOKENS_LIST[fromChain].find((t) => t.address === token);
-  const { balance } = useBalance({
-    account: account || "",
-    tokenAddress: token,
-    chainId: fromChain,
-  });
 
   const { data: fees } = useBridgeFees(
     {
@@ -117,8 +112,8 @@ const SendAction: React.FC = () => {
       : amount;
 
   const buttonDisabled =
-    balance?.lt(amount) ||
     (!hasToApprove && !canSend) ||
+    (hasToApprove && !canApprove) ||
     amountMinusFees.lte(0);
 
   return (

--- a/src/state/connection.ts
+++ b/src/state/connection.ts
@@ -1,6 +1,11 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { ethers } from "ethers";
-import { ChainId, UnsupportedChainIdError, isSupportedChainId } from "utils";
+import {
+  ChainId,
+  UnsupportedChainIdError,
+  isSupportedChainId,
+  getAddress,
+} from "utils";
 
 type State = {
   account?: string;
@@ -13,15 +18,6 @@ type State = {
 export type Update = Omit<State, "error" | "chainId"> & { chainId?: number };
 type ErrorUpdate = Required<Pick<State, "error">>;
 
-function getAddress(address: string | undefined) {
-  if (address === undefined) return;
-  try {
-    return ethers.utils.getAddress(address);
-  } catch (err) {
-    return address;
-  }
-}
-
 const initialState: State = {};
 
 const connectionSlice = createSlice({
@@ -30,7 +26,7 @@ const connectionSlice = createSlice({
   reducers: {
     update: (state, action: PayloadAction<Update>) => {
       const { account, chainId, provider, signer } = action.payload;
-      state.account = getAddress(account) ?? state.account;
+      state.account = account ? getAddress(account) : state.account;
       state.provider = provider ?? state.provider;
       // theres a potential problem with this: if onboard says a signer is undefined, we default them back
       // to the previous signer. This means we get out of sync with onboard and could have serious consequences.

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useEffect, useState } from "react";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
-import { ethers } from "ethers";
+import { ethers, BigNumber } from "ethers";
 import { bindActionCreators } from "redux";
 import {
   getDepositBox,
@@ -20,7 +20,7 @@ import {
   toAddress as toAddressAction,
   error as sendErrorAction,
 } from "./send";
-import { useAllowance, useBridgeFees } from "./chainApi";
+import { useAllowance, useBridgeFees, useBalances } from "./chainApi";
 import { add } from "./transactions";
 import { deposit as depositAction, toggle } from "./deposits";
 
@@ -253,3 +253,21 @@ export {
   useETHBalance,
   useBridgeFees,
 } from "./chainApi";
+
+export function useBalance(params: {
+  chainId: ChainId;
+  account: string;
+  tokenAddress: string;
+}) {
+  const { chainId, account, tokenAddress } = params;
+  const { data: balances, ...rest } = useBalances({ chainId, account });
+  const tokenList = TOKENS_LIST[chainId];
+  const selectedIndex = tokenList.findIndex(
+    ({ address }) => address === tokenAddress
+  );
+  const balance = balances ? balances[selectedIndex] : BigNumber.from("0");
+  return {
+    balance,
+    ...rest,
+  };
+}

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -3,3 +3,7 @@ import { ethers } from "ethers";
 export function isValidAddress(address: string) {
   return ethers.utils.isAddress(address);
 }
+
+export function getAddress(address: string) {
+  return ethers.utils.getAddress(address);
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,6 +7,7 @@ import wethLogo from "assets/weth-logo.svg";
 import arbitrumLogo from "assets/arbitrum-logo.svg";
 import memoize from "lodash.memoize";
 import umaLogo from "assets/UMA-round.svg";
+import { getAddress } from "./address";
 
 /* Colors and Media Queries section */
 
@@ -79,20 +80,20 @@ type TokenList = [
 export const TOKENS_LIST: Record<ChainId, TokenList> = {
   [ChainId.MAINNET]: [
     {
-      address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      address: getAddress("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
       name: "Wrapped Ethereum",
       symbol: "WETH",
       decimals: 18,
       logoURI: wethLogo,
-      bridgePool: "0x75a29a66452C80702952bbcEDd284C8c4CF5Ab17",
+      bridgePool: getAddress("0x75a29a66452C80702952bbcEDd284C8c4CF5Ab17"),
     },
     {
-      address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      address: getAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
       name: "USD Coin",
       symbol: "USDC",
       decimals: 6,
       logoURI: usdcLogo,
-      bridgePool: "0x54d8d0a00b8288b49694a765C59694ddE8e4B931",
+      bridgePool: getAddress("0x54d8d0a00b8288b49694a765C59694ddE8e4B931"),
     },
     {
       address: ethers.constants.AddressZero,
@@ -100,17 +101,17 @@ export const TOKENS_LIST: Record<ChainId, TokenList> = {
       symbol: "ETH",
       decimals: 18,
       logoURI: ethereumLogo,
-      bridgePool: "0x75a29a66452C80702952bbcEDd284C8c4CF5Ab17",
+      bridgePool: getAddress("0x75a29a66452C80702952bbcEDd284C8c4CF5Ab17"),
     },
   ],
   [ChainId.RINKEBY]: [
     {
-      address: "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+      address: getAddress("0xc778417E063141139Fce010982780140Aa0cD5Ab"),
       name: "Wrapped Ethereum",
       symbol: "WETH",
       decimals: 18,
       logoURI: wethLogo,
-      bridgePool: "0xf42bB7EC88d065dF48D60cb672B88F8330f9f764",
+      bridgePool: getAddress("0xf42bB7EC88d065dF48D60cb672B88F8330f9f764"),
     },
     {
       address: ethers.constants.AddressZero,
@@ -123,7 +124,7 @@ export const TOKENS_LIST: Record<ChainId, TokenList> = {
   ],
   [ChainId.KOVAN]: [
     {
-      address: "0xd0a1e359811322d97991e03f863a0c30c2cf029c",
+      address: getAddress("0xd0a1e359811322d97991e03f863a0c30c2cf029c"),
       name: "Wrapped Ethereum",
       symbol: "WETH",
       decimals: 18,
@@ -131,7 +132,7 @@ export const TOKENS_LIST: Record<ChainId, TokenList> = {
       bridgePool: "i",
     },
     {
-      address: "0x08ae34860fbfe73e223596e65663683973c72dd3",
+      address: getAddress("0x08ae34860fbfe73e223596e65663683973c72dd3"),
       name: "DAI Stablecoin",
       symbol: "DAI",
       decimals: 18,
@@ -149,20 +150,20 @@ export const TOKENS_LIST: Record<ChainId, TokenList> = {
   ],
   [ChainId.OPTIMISM]: [
     {
-      address: "0x4200000000000000000000000000000000000006",
+      address: getAddress("0x4200000000000000000000000000000000000006"),
       name: "Wrapped Ethereum",
       symbol: "WETH",
       decimals: 18,
       logoURI: wethLogo,
-      bridgePool: "0x75a29a66452C80702952bbcEDd284C8c4CF5Ab17",
+      bridgePool: getAddress("0x75a29a66452C80702952bbcEDd284C8c4CF5Ab17"),
     },
     {
-      address: "0x7f5c764cbc14f9669b88837ca1490cca17c31607",
+      address: getAddress("0x7f5c764cbc14f9669b88837ca1490cca17c31607"),
       name: "USD Coin",
       symbol: "USDC",
       decimals: 6,
       logoURI: usdcLogo,
-      bridgePool: "0x190978cC580f5A48D55A4A20D0A952FA1dA3C057",
+      bridgePool: getAddress("0x190978cC580f5A48D55A4A20D0A952FA1dA3C057"),
     },
     {
       address: ethers.constants.AddressZero,
@@ -170,12 +171,12 @@ export const TOKENS_LIST: Record<ChainId, TokenList> = {
       symbol: "ETH",
       decimals: 18,
       logoURI: ethereumLogo,
-      bridgePool: "0x75a29a66452C80702952bbcEDd284C8c4CF5Ab17",
+      bridgePool: getAddress("0x75a29a66452C80702952bbcEDd284C8c4CF5Ab17"),
     },
   ],
   [ChainId.KOVAN_OPTIMISM]: [
     {
-      address: "0x4200000000000000000000000000000000000006",
+      address: getAddress("0x4200000000000000000000000000000000000006"),
       name: "Wrapped Ethereum",
       symbol: "WETH",
       decimals: 18,
@@ -183,7 +184,7 @@ export const TOKENS_LIST: Record<ChainId, TokenList> = {
       bridgePool: "m",
     },
     {
-      address: "0x2a41F55E25EfEE3E53834140c0bD81dBF3464831",
+      address: getAddress("0x2a41F55E25EfEE3E53834140c0bD81dBF3464831"),
       name: "DAI (L2 Dai)",
       symbol: "DAI",
       decimals: 18,
@@ -201,20 +202,20 @@ export const TOKENS_LIST: Record<ChainId, TokenList> = {
   ],
   [ChainId.ARBITRUM]: [
     {
-      address: "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+      address: getAddress("0x82af49447d8a07e3bd95bd0d56f35241523fbab1"),
       name: "Wrapped Ethereum",
       symbol: "WETH",
       decimals: 18,
       logoURI: wethLogo,
-      bridgePool: "0x75a29a66452C80702952bbcEDd284C8c4CF5Ab17",
+      bridgePool: getAddress("0x75a29a66452C80702952bbcEDd284C8c4CF5Ab17"),
     },
     {
-      address: "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+      address: getAddress("0xff970a61a04b1ca14834a43f5de4533ebddb5cc8"),
       name: "USD Coin",
       symbol: "USDC",
       decimals: 6,
       logoURI: usdcLogo,
-      bridgePool: "0x54d8d0a00b8288b49694a765C59694ddE8e4B931",
+      bridgePool: getAddress("0x54d8d0a00b8288b49694a765C59694ddE8e4B931"),
     },
     {
       address: ethers.constants.AddressZero,
@@ -222,12 +223,12 @@ export const TOKENS_LIST: Record<ChainId, TokenList> = {
       symbol: "ETH",
       decimals: 18,
       logoURI: ethereumLogo,
-      bridgePool: "0x75a29a66452C80702952bbcEDd284C8c4CF5Ab17",
+      bridgePool: getAddress("0x75a29a66452C80702952bbcEDd284C8c4CF5Ab17"),
     },
   ],
   [ChainId.ARBITRUM_RINKEBY]: [
     {
-      address: "0xB47e6A5f8b33b3F17603C83a0535A9dcD7E32681",
+      address: getAddress("0xB47e6A5f8b33b3F17603C83a0535A9dcD7E32681"),
       name: "Wrapped Ethereum",
       symbol: "WETH",
       decimals: 18,

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -36,4 +36,3 @@ export function parseUnits(value: string, decimals: number): ethers.BigNumber {
 export function parseEther(value: string): ethers.BigNumber {
   return parseUnits(value, 18);
 }
-


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

This adds a `useBalance` function which just does some searching on `useBalances` under the hood. This also converts any possible constant addresses to the proper eth checksummed address so that looks ups will work.  