### PR TITLE
fix(across): fix confirmation screen bugs

### DIFF
--- a/src/components/Buttons/BaseButton.tsx
+++ b/src/components/Buttons/BaseButton.tsx
@@ -4,7 +4,7 @@ import { COLORS } from "utils";
 export const BaseButton = styled.button`
   --radius: 30px;
   border: none;
-  background: inherit;
+  background-color: inherit;
   cursor: pointer;
   padding: 16px;
   font-size: ${16 / 16}rem;

--- a/src/state/send.ts
+++ b/src/state/send.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { ethers } from "ethers";
 import { update } from "./connection";
+import { toggle as toggleConfirmationScreen } from "./deposits";
 
 import { ChainId, DEFAULT_FROM_CHAIN_ID, DEFAULT_TO_CHAIN_ID } from "utils";
 
@@ -53,10 +54,18 @@ const sendSlice = createSlice({
     },
   },
   extraReducers: (builder) =>
-    builder.addCase(update, (state, action) => {
-      state.toAddress = action.payload.account ?? state.toAddress;
-      return state;
-    }),
+    builder
+      .addCase(update, (state, action) => {
+        state.toAddress = action.payload.account ?? state.toAddress;
+        return state;
+      })
+      .addCase(toggleConfirmationScreen, (state, action) => {
+        // If the confirmation screen is closed, reset the state.
+        if (action.payload.showConfirmationScreen === false) {
+          state = initialState;
+        }
+        return state;
+      }),
 });
 
 const { actions, reducer } = sendSlice;


### PR DESCRIPTION
**Motivation**
This PR fixes some bugs with the confirmation screen


**Details**
The `background` property on the Button was set to `inherit` , so the confirmation screen button was inherting the linear background of the confirmation screen page. 
This PR also resets the state when the confirmation screen is closed.

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested