### PR TITLE
fix: fix send form persistence and clearing between currencies

### DIFF
--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { ethers } from "ethers";
+import { ethers, BigNumber } from "ethers";
 import { useSelect } from "downshift";
 import { max } from "utils";
 
@@ -29,9 +29,8 @@ import {
 
 const FEE_ESTIMATION = ".004";
 const CoinSelection = () => {
-  const [inputAmount, setInputAmount] = React.useState<string>("");
   const { account, isConnected } = useConnection();
-  const { setAmount, setToken, fromChain, toChain, amount } = useSend();
+  const { setAmount, setToken, fromChain, toChain, amount, token } = useSend();
 
   const [error, setError] = React.useState<Error>();
   const tokenList = TOKENS_LIST[fromChain];
@@ -52,15 +51,18 @@ const CoinSelection = () => {
     getMenuProps,
   } = useSelect({
     items: tokenList,
-    defaultSelectedItem: tokenList.find(
-      (t) => t.address === ethers.constants.AddressZero
-    ),
+    defaultSelectedItem: tokenList.find((t) => t.address === token),
     onSelectedItemChange: ({ selectedItem }) => {
       if (selectedItem) {
+        setInputAmount("");
+        setAmount({ amount: BigNumber.from("0") });
         setToken({ token: selectedItem.address });
       }
     },
   });
+  const [inputAmount, setInputAmount] = React.useState<string>(
+    selectedItem ? formatUnits(amount, selectedItem.decimals) : ""
+  );
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
@@ -82,9 +84,9 @@ const CoinSelection = () => {
   };
 
   useEffect(() => {
-    if (balances && amount && inputAmount !== "") {
+    if (balances && amount && inputAmount) {
       const selectedIndex = tokenList.findIndex(
-        ({ address }) => address === selectedItem!.address
+        ({ address }) => address === token
       );
       const balance = balances[selectedIndex];
       const isEth = tokenList[selectedIndex].symbol === "ETH";
@@ -103,8 +105,10 @@ const CoinSelection = () => {
       } else {
         setError(new Error("Insufficient balance."));
       }
+    } else {
+      setError(undefined);
     }
-  }, [balances, amount, selectedItem, tokenList, inputAmount]);
+  }, [balances, amount, token, tokenList, inputAmount]);
 
   const handleMaxClick = () => {
     if (balances && selectedItem) {

--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -61,7 +61,9 @@ const CoinSelection = () => {
     },
   });
   const [inputAmount, setInputAmount] = React.useState<string>(
-    selectedItem ? formatUnits(amount, selectedItem.decimals) : ""
+    selectedItem && amount.gt("0")
+      ? formatUnits(amount, selectedItem.decimals)
+      : ""
   );
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/SendAction/SendAction.tsx
+++ b/src/components/SendAction/SendAction.tsx
@@ -122,7 +122,7 @@ const SendAction: React.FC = () => {
   return (
     <AccentSection>
       <Wrapper>
-        {fees && tokenInfo && (
+        {amount.gt(0) && fees && tokenInfo && (
           <>
             <Info>
               <div>Time to {CHAINS[toChain].name}</div>


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

This fixes some subtle issues with the send form:
1. values clear between currencies. this is to prevent incorrect decimal conversions with old values
2. fees hide between currency switches. this is to prevent incorrect fee summaries when switching
3. form values persist between tab changes