### PR TITLE
fix: allow currency selection on send when not connected

### DIFF
--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -155,11 +155,7 @@ const CoinSelection = () => {
         <SectionTitle>Asset</SectionTitle>
         <InputGroup>
           <RoundBox as="label" {...getLabelProps()}>
-            <ToggleButton
-              type="button"
-              {...getToggleButtonProps()}
-              disabled={!isConnected}
-            >
+            <ToggleButton type="button" {...getToggleButtonProps()}>
               <Logo src={selectedItem?.logoURI} alt={selectedItem?.name} />
               <div>{selectedItem?.symbol}</div>
               <ToggleIcon />


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

enables currency selection before being connected