### PR TITLE
fix: change verbage when bridge fee too high

### DIFF
--- a/src/components/CoinSelection/CoinSelection.tsx
+++ b/src/components/CoinSelection/CoinSelection.tsx
@@ -139,7 +139,7 @@ const CoinSelection = () => {
   const errorMsg = error
     ? error.message
     : fees?.isAmountTooLow
-    ? "Bridge fee is too high. Try sending a larger amount."
+    ? "Bridge fee is high for this amount. Send a larger amount."
     : fees?.isLiquidityInsufficient
     ? `Insufficient liquidity for ${selectedItem?.symbol}.`
     : undefined;


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

just updates text when fee too high

![image](https://user-images.githubusercontent.com/4429761/140064232-bf3867a0-5146-45bc-b368-d1a8e4c04130.png)
