### PR TITLE
css override for onboard.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import { store } from "state";
 import { GlobalStyles } from "components";
 
 import App from "./App";
+import "./onboard-override.css";
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/onboard-override.css
+++ b/src/onboard-override.css
@@ -1,0 +1,51 @@
+/* Onboard custom CSS */
+.bn-onboard-custom .bn-onboard-modal-content {
+  background-color: #6cf9d8;
+  color: #2d2e33;
+  border-radius: 12px;
+}
+
+.bn-onboard-custom .bn-onboard-modal-select-wallets {
+  background-color: #2d2e33;
+  border-radius: 24px;
+  color: #ffffff;
+}
+
+.bn-onboard-custom .bn-onboard-modal-content-header-icon {
+  display: none;
+}
+
+.bn-onboard-custom .bn-onboard-modal-content-header-heading {
+  visibility: hidden;
+  /* position: absolute; */
+}
+
+.bn-onboard-custom .bn-onboard-modal-content-header-heading::before {
+  content: "Choose wallet provider";
+  visibility: visible;
+}
+
+.bn-onboard-custom .bn-onboard-select-description {
+  display: none;
+}
+
+.bn-onboard-custom .bn-onboard-select-wallet-info {
+  display: none;
+}
+
+.bn-onboard-custom .bn-onboard-modal-content-close {
+  height: 35px;
+}
+
+.bn-onboard-custom .bn-onboard-modal-content-close:hover {
+  background-color: #6cf9d8;
+  cursor: pointer;
+}
+
+.bn-onboard-custom .bn-onboard-modal-content-close svg {
+  height: 16px;
+  width: 16px;
+}
+.bn-onboard-custom .bn-onboard-modal-content-close svg path {
+  fill: #2d2e33;
+}


### PR DESCRIPTION
CSS override for onboard wallet connect:


<img width="572" alt="Screen Shot 2021-11-03 at 3 41 50 PM" src="https://user-images.githubusercontent.com/12792146/140214973-3729ab35-a2d3-46af-95b6-699e4b1324fd.png">
Signed-off-by: Tulun <jaykiraly@gmail.com>