### PR TITLE
fix: dyanmic gas price estimation, fix potential negative "max"

### DIFF
--- a/src/components/PoolForm/AddLiquidityForm.tsx
+++ b/src/components/PoolForm/AddLiquidityForm.tsx
@@ -1,5 +1,5 @@
 import { FC, ChangeEvent, useState, useCallback, useEffect } from "react";
-import { onboard, getGasPrice, formatEther, max } from "utils";
+import { onboard, getGasPrice, formatEther, max, estimateGas } from "utils";
 import { useConnection } from "state/hooks";
 import {
   RoundBox,
@@ -42,14 +42,6 @@ interface Props {
   setAmount: React.Dispatch<React.SetStateAction<string>>;
 }
 
-// for a dynamic gas estimation
-function estimateGas(
-  gas: BigNumber,
-  gasPriceWei: BigNumber,
-  buffer: BigNumber = GAS_PRICE_BUFFER
-) {
-  return gas.mul(gasPriceWei.add(buffer));
-}
 const AddLiquidityForm: FC<Props> = ({
   error,
   amount,
@@ -194,7 +186,13 @@ const AddLiquidityForm: FC<Props> = ({
                   formatEther(
                     max(
                       "0",
-                      balance.sub(estimateGas(ADD_LIQUIDITY_ETH_GAS, gasPrice))
+                      balance.sub(
+                        estimateGas(
+                          ADD_LIQUIDITY_ETH_GAS,
+                          gasPrice,
+                          GAS_PRICE_BUFFER
+                        )
+                      )
                     )
                   )
                 );

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -1,5 +1,4 @@
 import { ethers } from "ethers";
-
 import { CHAINS, ChainId } from "./constants";
 
 export async function switchChain(
@@ -35,4 +34,11 @@ export async function switchChain(
 
 export function isSupportedChainId(chainId: number): chainId is ChainId {
   return chainId in ChainId;
+}
+
+// this could be replaced eventually with a better gas estimator
+export async function getGasPrice(
+  provider: ethers.providers.JsonRpcProvider
+): Promise<ethers.BigNumber> {
+  return provider.getGasPrice();
 }

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -25,3 +25,12 @@ export function receiveAmount(amount: BigNumberish, fees?: PartialBridgeFees) {
     0
   );
 }
+
+// for a dynamic gas estimation
+export function estimateGas(
+  gas: BigNumber,
+  gasPriceWei: BigNumber,
+  buffer: BigNumber = BigNumber.from("0")
+) {
+  return gas.mul(gasPriceWei.add(buffer));
+}


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

when hitting max, gas was hardcoded to .1. We now estimate gas price using `ethers.getGasPrice()` and calculate gas fees based on a real world eth deposit here: https://etherscan.io/tx/0xa3a621d594c8b2a4f9260c9b8bbbd5e9b42fdbf92ec9322580d7caec51df8fd7
where gas used  was under 80k.  We set 80k gas as our estimate to get final fee. update constants to change estimations if they are wrong.