### PR TITLE
fix: disable add/remove liquidity if on wrong network

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -5,6 +5,7 @@ import { Header, SuperHeader } from "components";
 import { useConnection, useDeposits, useSend } from "state/hooks";
 import {
   DEFAULT_FROM_CHAIN_ID,
+  DEFAULT_TO_CHAIN_ID,
   CHAINS,
   UnsupportedChainIdError,
   switchChain,
@@ -12,8 +13,6 @@ import {
 import Footer from "components/Footer";
 
 interface Props {}
-
-const MAINNET_CHAINID = 1;
 
 // Need this component for useLocation hook
 const Routes: FC<Props> = () => {
@@ -26,7 +25,8 @@ const Routes: FC<Props> = () => {
     (error instanceof UnsupportedChainIdError || chainId !== fromChain);
   const wrongNetworkPool =
     provider &&
-    (error instanceof UnsupportedChainIdError || chainId !== MAINNET_CHAINID);
+    (error instanceof UnsupportedChainIdError ||
+      chainId !== DEFAULT_TO_CHAIN_ID);
   return (
     <>
       {wrongNetworkSend && location.pathname === "/" && (
@@ -43,8 +43,8 @@ const Routes: FC<Props> = () => {
         <SuperHeader>
           <div>
             You are on the wrong network. Please{" "}
-            <button onClick={() => switchChain(provider, MAINNET_CHAINID)}>
-              switch to {CHAINS[MAINNET_CHAINID].name}
+            <button onClick={() => switchChain(provider, DEFAULT_TO_CHAIN_ID)}>
+              switch to {CHAINS[DEFAULT_TO_CHAIN_ID].name}
             </button>
           </div>
         </SuperHeader>

--- a/src/components/PoolForm/AddLiquidityForm.tsx
+++ b/src/components/PoolForm/AddLiquidityForm.tsx
@@ -40,6 +40,7 @@ interface Props {
   setDepositUrl: React.Dispatch<React.SetStateAction<string>>;
   balance: ethers.BigNumber;
   setAmount: React.Dispatch<React.SetStateAction<string>>;
+  wrongNetwork?: boolean;
 }
 
 const AddLiquidityForm: FC<Props> = ({
@@ -54,6 +55,7 @@ const AddLiquidityForm: FC<Props> = ({
   setDepositUrl,
   balance,
   setAmount,
+  wrongNetwork,
 }) => {
   const { init } = onboard;
   const { isConnected, provider, signer, notify, account } = useConnection();
@@ -161,6 +163,12 @@ const AddLiquidityForm: FC<Props> = ({
     }
   };
 
+  function buttonMessage() {
+    if (!isConnected) return "Connect wallet";
+    if (wrongNetwork) return "Switch to Ethereum Mainnet";
+    if (userNeedsToApprove) return "Approve";
+    return "Add Liquidity";
+  }
   return (
     <>
       <FormHeader>Amount</FormHeader>
@@ -221,17 +229,14 @@ const AddLiquidityForm: FC<Props> = ({
         </Balance>
       )}
       <FormButton
+        disabled={wrongNetwork}
         onClick={() =>
           approveOrPoolTransactionHandler().catch((err) =>
             console.error("Error on click to approve or pool tx", err)
           )
         }
       >
-        {!isConnected
-          ? "Connect wallet"
-          : userNeedsToApprove
-          ? "Approve"
-          : "Add liquidity"}
+        {buttonMessage()}
         {txSubmitted ? <BouncingDotsLoader /> : null}
       </FormButton>
     </>

--- a/src/components/PoolForm/PoolForm.tsx
+++ b/src/components/PoolForm/PoolForm.tsx
@@ -2,7 +2,7 @@ import { FC, useState, ChangeEvent } from "react";
 import { ethers } from "ethers";
 import Tabs from "../Tabs";
 import AddLiquidityForm from "./AddLiquidityForm";
-import RemoveLiqudityForm from "./RemoveLiquidityForm";
+import RemoveLiquidityForm from "./RemoveLiquidityForm";
 import { QuerySubState } from "@reduxjs/toolkit/dist/query/core/apiState";
 
 import {
@@ -37,6 +37,7 @@ interface Props {
   setShowSuccess: React.Dispatch<React.SetStateAction<boolean>>;
   setDepositUrl: React.Dispatch<React.SetStateAction<string>>;
   balance: ethers.BigNumber;
+  wrongNetwork?: boolean;
 }
 
 const PoolForm: FC<Props> = ({
@@ -54,6 +55,7 @@ const PoolForm: FC<Props> = ({
   setShowSuccess,
   setDepositUrl,
   balance,
+  wrongNetwork,
 }) => {
   const [inputAmount, setInputAmount] = useState("");
   const [removeAmount, setRemoveAmount] = useState(0);
@@ -98,6 +100,7 @@ const PoolForm: FC<Props> = ({
       <Tabs>
         <TabContentWrapper data-label="Add">
           <AddLiquidityForm
+            wrongNetwork={wrongNetwork}
             error={error}
             amount={inputAmount}
             onChange={(event: ChangeEvent<HTMLInputElement>) =>
@@ -114,7 +117,8 @@ const PoolForm: FC<Props> = ({
           />
         </TabContentWrapper>
         <TabContentWrapper data-label="Remove">
-          <RemoveLiqudityForm
+          <RemoveLiquidityForm
+            wrongNetwork={wrongNetwork}
             removeAmount={removeAmount}
             setRemoveAmount={setRemoveAmount}
             bridgeAddress={bridgeAddress}

--- a/src/components/PoolForm/RemoveLiquidityForm.tsx
+++ b/src/components/PoolForm/RemoveLiquidityForm.tsx
@@ -38,6 +38,7 @@ interface Props {
   balance: ethers.BigNumber;
   position: ethers.BigNumber;
   feesEarned: ethers.BigNumber;
+  wrongNetwork?: boolean;
 }
 const RemoveLiqudityForm: FC<Props> = ({
   removeAmount,
@@ -51,9 +52,16 @@ const RemoveLiqudityForm: FC<Props> = ({
   balance,
   position,
   feesEarned,
+  wrongNetwork,
 }) => {
   const { init } = onboard;
   const { isConnected, provider, signer, notify } = useConnection();
+
+  function buttonMessage() {
+    if (!isConnected) return "Connect wallet";
+    if (wrongNetwork) return "Switch to Ethereum Mainnet";
+    return "Remove liquidity";
+  }
 
   const handleButtonClick = async () => {
     if (!provider) {
@@ -182,8 +190,8 @@ const RemoveLiqudityForm: FC<Props> = ({
         </>
       )}
       <RemoveFormButtonWrapper>
-        <RemoveFormButton onClick={handleButtonClick}>
-          {!isConnected ? "Connect wallet" : "Remove liquidity"}
+        <RemoveFormButton onClick={handleButtonClick} disabled={wrongNetwork}>
+          {buttonMessage()}
         </RemoveFormButton>
       </RemoveFormButtonWrapper>
     </>

--- a/src/components/PoolSelection/PoolSelection.tsx
+++ b/src/components/PoolSelection/PoolSelection.tsx
@@ -20,6 +20,7 @@ import {
 interface Props {
   token: Token;
   setToken: Dispatch<SetStateAction<Token>>;
+  wrongNetwork?: boolean;
 }
 
 const PoolSelection: FC<Props> = ({ token, setToken }) => {

--- a/src/views/Pool.tsx
+++ b/src/views/Pool.tsx
@@ -4,7 +4,13 @@ import Layout from "components/Layout";
 import PoolSelection from "components/PoolSelection";
 import PoolForm from "components/PoolForm";
 import DepositSuccess from "components/PoolForm/DepositSuccess";
-import { TOKENS_LIST, ChainId, Token } from "utils";
+import {
+  DEFAULT_TO_CHAIN_ID,
+  TOKENS_LIST,
+  ChainId,
+  Token,
+  UnsupportedChainIdError,
+} from "utils";
 import { useAppSelector, useConnection } from "state/hooks";
 import get from "lodash/get";
 import { poolClient } from "state/poolsApi";
@@ -32,9 +38,15 @@ const Pool: FC = () => {
     ])
   );
 
-  const { isConnected, account, signer, provider } = useConnection();
+  const { isConnected, account, signer, provider, error, chainId } =
+    useConnection();
 
   const queries = useAppSelector((state) => state.api.queries);
+
+  const wrongNetwork =
+    provider &&
+    (error instanceof UnsupportedChainIdError ||
+      chainId !== DEFAULT_TO_CHAIN_ID);
 
   // Update pool info when token changes
   useEffect(() => {
@@ -70,9 +82,14 @@ const Pool: FC = () => {
     <Layout>
       {!showSuccess ? (
         <>
-          <PoolSelection token={token} setToken={setToken} />
+          <PoolSelection
+            wrongNetwork={wrongNetwork}
+            token={token}
+            setToken={setToken}
+          />
           {!loadingPoolState ? (
             <PoolForm
+              wrongNetwork={wrongNetwork}
               symbol={token.symbol}
               icon={token.logoURI}
               decimals={token.decimals}


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Disables buttons to prevent doing transactions in poool tab on wrong network

![image](https://user-images.githubusercontent.com/4429761/140524268-8fd6b798-006e-44a2-a843-bf53332d35a1.png)
