### PR TITLE
fix: app erroring on pool tab when wrong network

### DIFF
--- a/src/components/PoolForm/AddLiquidityForm.tsx
+++ b/src/components/PoolForm/AddLiquidityForm.tsx
@@ -82,8 +82,9 @@ const AddLiquidityForm: FC<Props> = ({
   }, [account, tokenAddress, bridgeAddress, signer, balance]);
 
   useEffect(() => {
-    if (isConnected && symbol !== "ETH") checkIfUserHasToApprove();
-  }, [isConnected, symbol, checkIfUserHasToApprove]);
+    if (isConnected && symbol !== "ETH" && !wrongNetwork)
+      checkIfUserHasToApprove();
+  }, [isConnected, symbol, checkIfUserHasToApprove, wrongNetwork]);
 
   // TODO: move this to redux and update on an interval, every X blocks or something
   useEffect(() => {


### PR DESCRIPTION
Makes sure we dont try to pull approval/balances from contracts that dont exist on the wrong network