### PR TITLE
format to 4 decs

### DIFF
--- a/src/components/PoolForm/PoolForm.tsx
+++ b/src/components/PoolForm/PoolForm.tsx
@@ -18,7 +18,7 @@ import {
   PositionBlockItem,
   PositionBlockItemBold,
 } from "./PoolForm.styles";
-import { formatUnits } from "utils";
+import { formatUnits, numberFormatter } from "utils";
 
 interface Props {
   symbol: string;
@@ -60,7 +60,6 @@ const PoolForm: FC<Props> = ({
   const [inputAmount, setInputAmount] = useState("");
   const [removeAmount, setRemoveAmount] = useState(0);
   const [error] = useState<Error>();
-
   return (
     <Wrapper>
       <Info>
@@ -70,19 +69,19 @@ const PoolForm: FC<Props> = ({
           <PositionBlock>
             <PositionBlockItem>My deposit</PositionBlockItem>
             <PositionBlockItem>
-              {ethers.utils.formatUnits(position, decimals)} {symbol}
+              {formatUnits(position, decimals)} {symbol}
             </PositionBlockItem>
           </PositionBlock>
           <PositionBlock>
             <PositionBlockItem>Fees earned</PositionBlockItem>
             <PositionBlockItem>
-              {ethers.utils.formatUnits(feesEarned, decimals)} {symbol}
+              {formatUnits(feesEarned, decimals)} {symbol}
             </PositionBlockItem>
           </PositionBlock>
           <PositionBlock>
             <PositionBlockItemBold>Total</PositionBlockItemBold>
             <PositionBlockItemBold>
-              {ethers.utils.formatUnits(totalPosition, decimals)} {symbol}
+              {formatUnits(totalPosition, decimals)} {symbol}
             </PositionBlockItemBold>
           </PositionBlock>
         </PositionWrapper>
@@ -94,7 +93,7 @@ const PoolForm: FC<Props> = ({
         </ROIWrapper>
         <ROIWrapper>
           <ROIItem>Estimated APY:</ROIItem>
-          <ROIItem>{apy}</ROIItem>
+          <ROIItem>{numberFormatter(Number(apy)).replaceAll(",", "")}%</ROIItem>
         </ROIWrapper>
       </Info>
       <Tabs>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -13,7 +13,7 @@ export function shortenAddress(address: string): string {
   return `${address.substr(0, 4)}...${address.substr(-4)}`;
 }
 
-const numberFormatter = new Intl.NumberFormat("en-US", {
+export const numberFormatter = new Intl.NumberFormat("en-US", {
   minimumFractionDigits: 4,
 }).format;
 export function formatUnits(

--- a/src/views/Pool.tsx
+++ b/src/views/Pool.tsx
@@ -89,8 +89,8 @@ const Pool: FC = () => {
               }
               apy={
                 pool && pool.estimatedApy
-                  ? `${Number(pool.estimatedApy) * 100}%`
-                  : "0%"
+                  ? `${Number(pool.estimatedApy) * 100}`
+                  : "0"
               }
               position={
                 userPosition


### PR DESCRIPTION
Format Pool values and APY to 4 decimals.

https://app.shortcut.com/uma-project/story/2880/reduce-total-pool-size-and-estimate-apy-to-4-decimals-and-add-a-space-between-pool-size-amount-and-the-asset-e-g-eth-same

Signed-off-by: Tulun <jaykiraly@gmail.com>